### PR TITLE
Fix KaTeX defaultProps deprecation warning causing error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,21 +72,23 @@ html, body {
 export interface KatexProps extends ContentOptions, Omit<WebViewSharedProps, 'source'> {}
 
 export default function Katex({
-  expression,
-  displayMode,
+  expression = '',
+  displayMode = false,
   output,
   leqno,
   fleqn,
-  throwOnError,
-  errorColor,
-  macros,
+  throwOnError = false,
+  errorColor = '#f00',
+  macros = {},
   minRuleThickness,
-  colorIsTextColor,
+  colorIsTextColor = false,
   maxSize,
   maxExpand,
   strict,
   trust,
   globalGroup,
+  inlineStyle = defaultInlineStyle,
+  style = defaultStyle,
   ...webViewProps
 }: KatexProps) {
   return (
@@ -109,19 +111,9 @@ export default function Katex({
           strict,
           trust,
           globalGroup,
+          inlineStyle,
         }),
       }}
     />
   );
 }
-
-Katex.defaultProps = {
-  expression: '',
-  displayMode: false,
-  throwOnError: false,
-  errorColor: '#f00',
-  inlineStyle: defaultInlineStyle,
-  style: defaultStyle,
-  macros: {},
-  colorIsTextColor: false,
-};


### PR DESCRIPTION
Fixes #19

Resolve warning about KaTeX defaultProps deprecation.

* Remove `defaultProps` from the `Katex` function component.
* Add default parameter values to the `Katex` function component.
* Set default values for `expression`, `displayMode`, `throwOnError`, `errorColor`, `inlineStyle`, `style`, `macros`, and `colorIsTextColor`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/3axap4eHko/react-native-katex/pull/21?shareId=61c8e1cc-8a97-4a0c-8911-55e99a8efcc2).